### PR TITLE
Add other hidapi libs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: ruby
 rvm:
   - 2.1.5
+before_install:
+  - sudo apt-get -y install libhidapi-dev libhidapi-hidraw0 libhidapi-libusb0

--- a/README.md
+++ b/README.md
@@ -10,7 +10,13 @@ This gem is my first attempt at writing any FFI code, and my first attempt to us
 
 The gem requires the hidapi library to be installed and available to Ruby. On Mac with homebrew installed, this can be done with the command:
 
+### For macOS
+
     $ brew install hidapi
+
+### For Debian
+
+    $ sudo apt install libhidapi-dev libhidapi-hidraw0 libhidapi-libusb0
 
 ## Installation
 

--- a/lib/hid_api.rb
+++ b/lib/hid_api.rb
@@ -4,8 +4,10 @@ require "ffi"
 module HidApi
   class HidError < StandardError; end
 
+  HIDAPI_LIBS = %w(hidapi hidapi-libusb hidapi-hidraw).freeze
+
   extend FFI::Library
-  ffi_lib "hidapi"
+  ffi_lib HIDAPI_LIBS
 
   autoload :Deprecated, "hid_api/deprecated"
   autoload :Device,     "hid_api/device"

--- a/spec/hid_api_spec.rb
+++ b/spec/hid_api_spec.rb
@@ -4,8 +4,4 @@ describe HidApi do
   it "has a version number" do
     expect(HidApi::VERSION).not_to be nil
   end
-
-  it "does something useful" do
-    expect(false).to eq(true)
-  end
 end


### PR DESCRIPTION
- See the [ffi wiki page]((https://github.com/ffi/ffi/wiki/Loading-Libraries)) and fixed it to load the library on other OSs as well (mainly I want to use Raspbian v10).
- Added "For Debian" (and "For macOS") to "Dependencies" of README.md
- Added code to hidapi libraries to OS in Travis CI.
- Deleted meaningless spec.
- I confirmed that the test passed in Travis CI.
    - https://travis-ci.com/github/dounokouno/ruby_hid_api

Please confirm it is.